### PR TITLE
[Feat] Add content for improving SEO and JP access

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -21,6 +21,7 @@ const PageTemplate = css`
     height: 0px;
     overflow: hidden;
     margin-bottom: 3.2rem;
+    background-color: #efefef;
   }
   .responsive-iframe iframe {
     position: absolute;
@@ -68,6 +69,24 @@ const About: React.SFC = () => (
                 </small>
               </p>
               <p>
+                <i>English follows Japanese</i>
+              </p>
+              <p>【 好きなこと、学びたいこと、どんどんやろう！】</p>
+              <p>
+                Yamagata Developers Society
+                は、山形でWeb開発に関わっているエンジニア向けのグループです。
+                dプログラマー、SE、デザイナー、勉強中の人等が集い、互いのスキルアップや仕事での連携を目指す、オープンなMeet
+                up を開催します。
+              </p>
+              <p>
+                持物は【学びたい言語・スキル】と【エンジニア魂】。そして、飲物！持参！
+                (珈琲・紅茶・冷たいお茶・少しのビールのご用意ございます)
+              </p>
+              <p>
+                おいしいものを食べたり飲んだりしながら、一緒に山形のWeb開発を一緒に盛り上げましょう！
+              </p>
+              <hr />
+              <p>
                 Yamagata Developer Society is a community for professionals and students alike. We
                 hold monthly developer meetups at{' '}
                 <a href="https://www.coworking-too.com/">coworking space too</a> in downtown
@@ -86,7 +105,7 @@ const About: React.SFC = () => (
                 welcome!
               </p>
               <p>
-                If you are looking for some other way to connect with us, you can find us on{' '}
+                If you are looking for some other way to connect with us, please find us on{' '}
                 <a href="https://twitter.com/yamagataDevSoc">Twitter</a>.
               </p>
             </div>

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -30,7 +30,7 @@ export const SiteTitle = styled.h1`
 
 export const SiteDescription = styled.h2`
   z-index: 10;
-  margin: 0;
+  margin: 6px 0 0;
   padding: 5px 0;
   font-size: 2.2rem;
   font-weight: 300;

--- a/src/website-config.ts
+++ b/src/website-config.ts
@@ -26,7 +26,7 @@ export interface WebsiteConfig {
 
 const config: WebsiteConfig = {
   title: 'Yamagata Developers Society',
-  description: 'A community of professionals sharing knowledge',
+  description: '山形でWeb開発に関わっているエンジニア向けの勉強会',
   coverImage: 'img/common/yds-social-bg.jpg',
   logo: 'img/common/yds-logo.png',
   siteUrl: 'https://yamagata-developers-society.github.io/blog/',


### PR DESCRIPTION
## Overview

- Change site description used in meta tags and top page hero description.
- Add Japanese description to about page

<img width="1214" alt="Screen Shot 2019-12-03 at 22 34 09" src="https://user-images.githubusercontent.com/6524512/70055630-4a062200-161d-11ea-9952-0f41f8209928.png">
<img width="1210" alt="Screen Shot 2019-12-03 at 22 33 51" src="https://user-images.githubusercontent.com/6524512/70055632-4a9eb880-161d-11ea-8481-dd60c6a81cd7.png">
